### PR TITLE
Update inputOverrides description on CRD

### DIFF
--- a/crd/function-test.yaml
+++ b/crd/function-test.yaml
@@ -94,11 +94,11 @@ spec:
                         nullable: false
                         x-kubernetes-preserve-unknown-fields: true
                         description: |
-                          Fully *replace* input values with those provided. If
-                          this is a non-variant test case, these will carry
-                          forward to subsequent test cases. This must be an
-                          object, but the values may be simple values, lists,
-                          or objects. Koreo Expressions are not allowed.
+                          Patch input values with those provided. If this is a
+                          non-variant test case, these will carry forward to
+                          subsequent test cases. This must be an object, but
+                          the values may be simple values, lists, or objects.
+                          Koreo Expressions are not allowed.
 
                       currentResource:
                         type: object


### PR DESCRIPTION
Update the description on `inputOverrides` for the FunctionTest CRD to make it clear that the value _patches_ inputs with the values provided.