### PR TITLE
Only load schemas from files if not already set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo-core"
-version = "0.1.2"
+version = "0.1.3"
 description = "Type-safe and testable KRM Templates and Workflows."
 authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},

--- a/src/koreo/constants.py
+++ b/src/koreo/constants.py
@@ -1,5 +1,7 @@
 PREFIX = "koreo.dev"
 
+DEFAULT_API_VERSION = "v1beta1"
+
 ACTIVE_LABEL = f"{PREFIX}/active"
 
 LAST_APPLIED_ANNOTATION = f"{PREFIX}/last-applied-configuration"


### PR DESCRIPTION
When deployed, Koreo needs access to its schemas to validate resources. This change sets the foundation for allowing the controller to load the schemas from the cluster.