### PR TITLE
Correct handling of resources with empty spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo-core"
-version = "0.1.8"
+version = "0.1.9"
 description = "Type-safe and testable KRM Templates and Workflows."
 authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},

--- a/src/koreo/resource_function/prepare.py
+++ b/src/koreo/resource_function/prepare.py
@@ -93,7 +93,7 @@ async def prepare_resource_function(
         case (resource_api, resource_id, own_resource, readonly, delete_if_exists):
             used_vars.update(extract_argument_structure(resource_id.ast))
 
-    match _prepare_resource_template(cel_env=env, spec=spec, readonly=readonly):
+    match _prepare_resource_template(cel_env=env, spec=spec):
         case PermFail() as err:
             return err
 
@@ -235,7 +235,7 @@ def _prepare_api_config(
 
 
 def _prepare_resource_template(
-    cel_env: celpy.Environment, spec: dict, readonly: bool
+    cel_env: celpy.Environment, spec: dict
 ) -> structure.InlineResourceTemplate | structure.ResourceTemplateRef | PermFail:
     match spec:
         case {"resource": resource_template}:
@@ -245,13 +245,7 @@ def _prepare_resource_template(
                 case PermFail() as err:
                     return err
                 case None:
-                    if readonly:
-                        return structure.InlineResourceTemplate()
-
-                    return PermFail(
-                        message=f"Empty resource template ({resource_template})",
-                        location="spec.resource",
-                    )
+                    return structure.InlineResourceTemplate()
                 case celpy.Runner() as template_expression:
                     return structure.InlineResourceTemplate(
                         template=template_expression

--- a/src/koreo/resource_function/reconcile/__init__.py
+++ b/src/koreo/resource_function/reconcile/__init__.py
@@ -460,6 +460,8 @@ async def _construct_resource_template(
                     return err
                 case celtypes.MapType() as materialized:
                     pass
+                case None:
+                    materialized = celtypes.MapType()
                 case _ as bad_type:
                     return PermFail(
                         message=f"Expected mapping, but received {type(bad_type)} for `spec.resource`",
@@ -670,7 +672,7 @@ async def _create_api_resource(
 
 def _forced_overlay(resource_api: type[APIObject], name: str, namespace: str | None):
     # Only include namespace when the resource API is namespaced
-    metadata: dict[str, object] = {"name": name}
+    metadata: dict[str, str] = {"name": name}
     if namespace is not None:
         metadata["namespace"] = namespace
 
@@ -678,9 +680,9 @@ def _forced_overlay(resource_api: type[APIObject], name: str, namespace: str | N
         {
             "apiVersion": resource_api.version,
             "kind": resource_api.kind,
-            "metadata": metadata
+            "metadata": metadata,
         }
-   )
+    )
 
     # Perhaps this could occur with some corrupt name config?
     if not isinstance(forced_overlay, celtypes.MapType):

--- a/src/koreo/workflow/reconcile.py
+++ b/src/koreo/workflow/reconcile.py
@@ -424,7 +424,6 @@ async def _reconcile_ref_switch(
     inputs: celtypes.Value,
     location: str,
 ):
-
     # This gives the switch-on expression access to direct outcomes through
     # `steps`, but also to the step's `inputs`. In addition to possible
     # convenience, this gives the switch access to the iterated values from a
@@ -681,14 +680,6 @@ def _condition_helper(
     status = "True"
     location = workflow_key
 
-    if outcome is None:
-        return Condition(
-            type=condition_type,
-            reason=reason,
-            message=message,
-            status=status,
-            location=location,
-        )
 
     match outcome:
         case result.DepSkip(message=skip_message, location=location):

--- a/tests/koreo/resource_function/test_reconcile.py
+++ b/tests/koreo/resource_function/test_reconcile.py
@@ -1,4 +1,0 @@
-import copy
-import unittest
-
-from koreo.resource_function import reconcile

--- a/tests/koreo/workflow/test_reconcile.py
+++ b/tests/koreo/workflow/test_reconcile.py
@@ -81,9 +81,9 @@ class TestReconcileWorkflow(unittest.IsolatedAsyncioTestCase):
             location="unittest:sub_step_two.return",
         )
 
-        assert is_unwrapped_ok(
-            sub_step_two_return_value
-        ), f"{sub_step_two_return_value}"
+        assert is_unwrapped_ok(sub_step_two_return_value), (
+            f"{sub_step_two_return_value}"
+        )
 
         sub_workflow = workflow_structure.Workflow(
             name="unit-test",
@@ -316,15 +316,6 @@ class TestReconcileWorkflow(unittest.IsolatedAsyncioTestCase):
 
 
 class TestConditionHelper(unittest.TestCase):
-    def test_none_outcome(self):
-        condition = reconcile._condition_helper(
-            condition_type="UnitTest",
-            thing_name="unit test",
-            outcome=None,
-            workflow_key="unit-test-flow",
-        )
-
-        self.assertEqual("Pending", condition.get("reason"))
 
     def test_ok_outcome_that_is_none(self):
         condition = reconcile._condition_helper(


### PR DESCRIPTION
Resources such as namespaces have no spec. This was being incorrectly treated as an error condition.

This also corrects the handling of conditions for steps who's return value is `None`.