### PR TITLE
Move PLURAL_LOOKUP_NEEDED to constants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo-core"
-version = "0.1.10"
+version = "0.1.11"
 description = "Type-safe and testable KRM Templates and Workflows."
 authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},

--- a/src/koreo/constants.py
+++ b/src/koreo/constants.py
@@ -6,10 +6,16 @@ ACTIVE_LABEL = f"{PREFIX}/active"
 
 LAST_APPLIED_ANNOTATION = f"{PREFIX}/last-applied-configuration"
 
+DEFAULT_CREATE_DELAY = 30
+DEFAULT_DELETE_DELAY = 15
 DEFAULT_LOAD_RETRY_DELAY = 30
+DEFAULT_PATCH_DELAY = 30
 
 KOREO_DIRECTIVE_KEYS: set[str] = {
     "x-koreo-compare-as-set",
     "x-koreo-compare-as-map",
     "x-koreo-compare-last-applied",
 }
+
+
+PLURAL_LOOKUP_NEEDED = "+++missing plural+++"

--- a/src/koreo/resource_function/prepare.py
+++ b/src/koreo/resource_function/prepare.py
@@ -10,6 +10,7 @@ import kr8s
 import celpy
 
 from koreo import cache
+from koreo import constants
 from koreo import registry
 from koreo import schema
 from koreo.cel.functions import koreo_function_annotations
@@ -38,10 +39,6 @@ logging.getLogger("NameContainer").setLevel(logging.WARNING)
 logging.getLogger("Evaluator").setLevel(logging.WARNING)
 logging.getLogger("evaluation").setLevel(logging.WARNING)
 logging.getLogger("celtypes").setLevel(logging.WARNING)
-
-DEFAULT_CREATE_DELAY = 30
-DEFAULT_DELETE_DELAY = 15
-DEFAULT_PATCH_DELAY = 30
 
 
 async def prepare_resource_function(
@@ -185,7 +182,7 @@ def _location(cache_key: str, extra: str | None = None) -> str:
 
 def _prepare_api_config(
     cel_env: celpy.Environment, spec: dict
-) -> tuple[type[APIObject], celpy.celpy.Runner, bool, bool, bool] | PermFail:
+) -> tuple[type[APIObject], celpy.Runner, bool, bool, bool] | PermFail:
     api_version = spec.get("apiVersion")
     kind = spec.get("kind")
     name = spec.get("name")
@@ -196,7 +193,7 @@ def _prepare_api_config(
 
     plural = spec.get("plural")
     if not plural:
-        plural = structure.PLURAL_LOOKUP_NEEDED
+        plural = constants.PLURAL_LOOKUP_NEEDED
 
     namespaced = spec.get("namespaced", True)
     owned = spec.get("owned", True)
@@ -433,13 +430,13 @@ def _prepare_create(
     cel_env: celpy.Environment, spec: dict | None
 ) -> structure.Create | PermFail:
     if not spec:
-        return structure.Create(enabled=True, delay=DEFAULT_CREATE_DELAY)
+        return structure.Create(enabled=True, delay=constants.DEFAULT_CREATE_DELAY)
 
     enabled = spec.get("enabled", True)
     if not enabled:
         return structure.Create(enabled=False)
 
-    delay = spec.get("delay", DEFAULT_CREATE_DELAY)
+    delay = spec.get("delay", constants.DEFAULT_CREATE_DELAY)
 
     overlay_spec = spec.get("overlay")
     match prepare_overlay_expression(
@@ -461,7 +458,7 @@ def _prepare_create(
 def _prepare_update(spec: dict | None) -> structure.Update | PermFail:
     match spec:
         case None:
-            return structure.UpdatePatch(delay=DEFAULT_PATCH_DELAY)
+            return structure.UpdatePatch(delay=constants.DEFAULT_PATCH_DELAY)
         case {"patch": {"delay": delay}}:
             return structure.UpdatePatch(delay=delay)
         case {"recreate": {"delay": delay}}:

--- a/src/koreo/resource_function/prepare.py
+++ b/src/koreo/resource_function/prepare.py
@@ -221,13 +221,20 @@ def _prepare_api_config(
             # Just needed to set name
             pass
 
-    resource_api = kr8s.objects.new_class(
-        version=api_version,
-        kind=kind,
-        plural=plural,
-        namespaced=namespaced,
-        asyncio=True,
-    )
+    try:
+        resource_api = kr8s.objects.get_class(
+            version=api_version,
+            kind=kind,
+            _asyncio=True,
+        )
+    except KeyError:
+        resource_api = kr8s.objects.new_class(
+            version=api_version,
+            kind=kind,
+            plural=plural,
+            namespaced=namespaced,
+            asyncio=True,
+        )
     return (resource_api, resource_id, owned, readonly, delete_if_exists)
 
 

--- a/src/koreo/resource_function/reconcile/__init__.py
+++ b/src/koreo/resource_function/reconcile/__init__.py
@@ -24,6 +24,7 @@ from koreo.constants import (
     DEFAULT_LOAD_RETRY_DELAY,
     KOREO_DIRECTIVE_KEYS,
     LAST_APPLIED_ANNOTATION,
+    PLURAL_LOOKUP_NEEDED,
 )
 from koreo.resource_template.structure import ResourceTemplate
 from koreo.result import PermFail, Retry, UnwrappedOutcome, is_unwrapped_ok
@@ -180,7 +181,7 @@ async def reconcile_krm_resource(
     # TODO: Would we rather do this at prepare time? Or, perhaps there should
     # be some other process that ensures we lookup the plurals in advance when
     # the resource function is loaded?
-    if crud_config.resource_api.plural == structure.PLURAL_LOOKUP_NEEDED:
+    if crud_config.resource_api.plural == PLURAL_LOOKUP_NEEDED:
         kind = crud_config.resource_api.kind
 
         plural = await get_plural_kind(

--- a/src/koreo/resource_function/structure.py
+++ b/src/koreo/resource_function/structure.py
@@ -57,9 +57,6 @@ class DeleteDestroy(NamedTuple):
     force: bool = False
 
 
-PLURAL_LOOKUP_NEEDED = "+++missing plural+++"
-
-
 class CRUDConfig(NamedTuple):
     resource_api: type[APIObject]
     resource_id: celpy.Runner


### PR DESCRIPTION
We need to be able to detect missing plural within the controller as well. Moving the marker to constants for cleaner looking imports and intent.