### PR TITLE
Include CRD files in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ build-backend = "pdm.backend"
 [tool.pdm]
 distribution = true
 
+[tool.pdm.build]
+package-dir = "src"
+includes = ["src/koreo/**/*", "crd/*.yaml"]
+
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = [


### PR DESCRIPTION
## Summary
- Updates pyproject.toml to explicitly include CRD YAML files in the package build
- Ensures CRD files are available when koreo-core is installed as a dependency

## Context
This change enables dependent packages (like koreo-tooling) to access CRD files from the installed koreo-core package instead of bundling their own copies, reducing duplication and maintenance overhead.

## Test plan
- [ ] Verify package builds correctly with CRD files included
- [ ] Test that dependent packages can access CRDs from installed koreo-core
- [ ] Confirm no breaking changes to existing functionality