### PR TITLE
Correct refSwitch workflow resources var reuse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo-core"
-version = "0.1.14"
+version = "0.1.15"
 description = "Type-safe and testable KRM Templates and Workflows."
 authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},

--- a/src/koreo/workflow/prepare.py
+++ b/src/koreo/workflow/prepare.py
@@ -583,7 +583,7 @@ def _load_logic_switch(
                 location=f"{location}.cases[{idx}].default",
             )
 
-        resources, logic = _load_logic(
+        logic_resources, logic = _load_logic(
             logic_ref=case_spec, location=f"{location}[{idx}]"
         )
 
@@ -600,8 +600,8 @@ def _load_logic_switch(
         if is_default:
             default_logic = logic
 
-        if resources:
-            resources.update(resources)
+        if logic_resources:
+            resources.update(logic_resources)
 
     functions_ready = unwrapped_combine(logic_map.values())
     if is_error(functions_ready):


### PR DESCRIPTION
The `resources` variable name was used within the loop and as an accumulator. This caused references to be lost, which resulted in incomplete subscriptions.